### PR TITLE
Support  OpenGVLab / Mini-InternVL-Chat-4B-V1-5

### DIFF
--- a/backend/phintern.py
+++ b/backend/phintern.py
@@ -1,0 +1,138 @@
+import os
+from transformers import AutoTokenizer, AutoModel
+from vision_qna import *
+import torch
+import torchvision.transforms as T
+from torchvision.transforms.functional import InterpolationMode
+
+# OpenGVLab/Mini-InternVL-Chat-4B-V1-5
+
+IMAGENET_MEAN = (0.485, 0.456, 0.406)
+IMAGENET_STD = (0.229, 0.224, 0.225)
+
+def build_transform(input_size):
+    MEAN, STD = IMAGENET_MEAN, IMAGENET_STD
+    transform = T.Compose([
+        T.Lambda(lambda img: img.convert('RGB') if img.mode != 'RGB' else img),
+        T.Resize((input_size, input_size), interpolation=InterpolationMode.BICUBIC),
+        T.ToTensor(),
+        T.Normalize(mean=MEAN, std=STD)
+    ])
+    return transform
+
+def find_closest_aspect_ratio(aspect_ratio, target_ratios, width, height, image_size):
+    best_ratio_diff = float('inf')
+    best_ratio = (1, 1)
+    area = width * height
+    for ratio in target_ratios:
+        target_aspect_ratio = ratio[0] / ratio[1]
+        ratio_diff = abs(aspect_ratio - target_aspect_ratio)
+        if ratio_diff < best_ratio_diff:
+            best_ratio_diff = ratio_diff
+            best_ratio = ratio
+        elif ratio_diff == best_ratio_diff:
+            if area > 0.5 * image_size * image_size * ratio[0] * ratio[1]:
+                best_ratio = ratio
+    return best_ratio
+
+def dynamic_preprocess(image, min_num=1, max_num=6, image_size=448, use_thumbnail=False):
+    orig_width, orig_height = image.size
+    aspect_ratio = orig_width / orig_height
+
+    # calculate the existing image aspect ratio
+    target_ratios = set(
+        (i, j) for n in range(min_num, max_num + 1) for i in range(1, n + 1) for j in range(1, n + 1) if
+        i * j <= max_num and i * j >= min_num)
+    target_ratios = sorted(target_ratios, key=lambda x: x[0] * x[1])
+
+    # find the closest aspect ratio to the target
+    target_aspect_ratio = find_closest_aspect_ratio(
+        aspect_ratio, target_ratios, orig_width, orig_height, image_size)
+
+    # calculate the target width and height
+    target_width = image_size * target_aspect_ratio[0]
+    target_height = image_size * target_aspect_ratio[1]
+    blocks = target_aspect_ratio[0] * target_aspect_ratio[1]
+
+    # resize the image
+    resized_img = image.resize((target_width, target_height))
+    processed_images = []
+    for i in range(blocks):
+        box = (
+            (i % (target_width // image_size)) * image_size,
+            (i // (target_width // image_size)) * image_size,
+            ((i % (target_width // image_size)) + 1) * image_size,
+            ((i // (target_width // image_size)) + 1) * image_size
+        )
+        # split the image
+        split_img = resized_img.crop(box)
+        processed_images.append(split_img)
+    assert len(processed_images) == blocks
+    if use_thumbnail and len(processed_images) != 1:
+        thumbnail_img = image.resize((image_size, image_size))
+        processed_images.append(thumbnail_img)
+    return processed_images
+
+
+def load_image(image, input_size=448, max_num=6):
+    #image = Image.open(image_file).convert('RGB')
+    transform = build_transform(input_size=input_size)
+    images = dynamic_preprocess(image, image_size=input_size, use_thumbnail=True, max_num=max_num)
+    pixel_values = [transform(image) for image in images]
+    pixel_values = torch.stack(pixel_values)
+    return pixel_values
+
+
+class VisionQnA(VisionQnABase):
+    model_name: str = "internvl-chat-4b"
+    format: str = "phintern"
+    
+    def __init__(self, model_id: str, device: str, device_map: str = 'auto', extra_params = {}, format = None):
+        super().__init__(model_id, device, device_map, extra_params, format)
+        
+        self.tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=self.params.get('trust_remote_code', False))
+        self.model = AutoModel.from_pretrained(**self.params).eval()
+
+        self.model.img_context_token_id = self.tokenizer.convert_tokens_to_ids('<IMG_CONTEXT>')
+
+        if self.tokenizer.convert_tokens_to_ids('<|end|>') != 0:
+            self.eos_token_id = self.tokenizer.convert_tokens_to_ids('<|end|>')  # 92542, InternLM2
+        else:
+            self.eos_token_id = self.tokenizer.eos_token_id
+
+        print(f"Loaded on device: {self.model.device} with dtype: {self.model.dtype}")
+    
+    async def chat_with_images(self, request: ImageChatRequest) -> str:
+        images, prompt = await chatml_prompt_from_messages(request.messages, img_tok='')
+        
+        images = [load_image(image).to(self.model.dtype).cuda() for image in images]
+        if len(images) > 1:
+            pixel_values = torch.cat(images, dim=0)
+        else:
+            pixel_values = images[0]
+
+        default_params = {
+            'num_beams': 1,
+            'max_new_tokens': 512,
+            'do_sample': False,
+            'eos_token_id': self.eos_token_id,
+        }
+
+        generation_config = self.get_generation_params(request, default_params)
+
+        del generation_config['use_cache']
+
+        image_tokens = '<img>' + '<IMG_CONTEXT>' * self.model.num_image_token * pixel_values.shape[0] + '</img>\n'
+        model_inputs = self.tokenizer(image_tokens + prompt, return_tensors='pt')
+        input_ids = model_inputs['input_ids'].cuda()
+        attention_mask = model_inputs['attention_mask'].cuda()
+        
+        output = self.model.generate(
+            pixel_values=pixel_values,
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            **generation_config,
+        )
+        response = self.tokenizer.decode(output[0], skip_special_tokens=True)
+
+        return response.split('<|end|>')[0].strip()

--- a/vision_qna.py
+++ b/vision_qna.py
@@ -357,6 +357,38 @@ async def chatml_prompt_from_messages(messages: list[Message], img_tok = "<image
 
     return images, prompt
 
+async def phintern_prompt_from_messages(messages: list[Message], img_tok = "<image>\n"):
+    prompt = ''
+    images = []
+    generation_msg = "<s><|assistant|>\n"
+
+    if messages and messages[-1].role == 'assistant':
+        generation_msg += messages[-1].content[0].text
+        messages.pop(-1)
+
+    for m in messages:
+        if m.role == 'user':
+            text = ''
+            has_image = False
+
+            for c in m.content:
+                if c.type == 'image_url':
+                    images.extend([ await url_to_image(c.image_url.url) ])
+                    has_image = True
+                if c.type == 'text':
+                    text = c.text
+
+            img_tag = img_tok if has_image else ''
+            prompt += f"<s><|user|>\n{img_tag}{text}<|end|>"
+        elif m.role == 'assistant':
+            for c in m.content:
+                if c.type == 'text':
+                    prompt += f"<s><|assistant|>\n{c.text}<|end|>"
+
+    prompt += generation_msg
+
+    return images, prompt
+
 async def gemma_prompt_from_messages(messages: list[Message], img_tok = "<image>\n"):
     prompt = ''
     images = []
@@ -530,6 +562,8 @@ async def prompt_from_messages(messages: list[Message], format: str) -> str:
         'chatml': chatml_prompt_from_messages,
         'gemma': gemma_prompt_from_messages,
         'fuyu': fuyu_prompt_from_messages,
+        'phintern': phintern_prompt_from_messages,
+
     }
 
     if format not in known_formats:
@@ -549,6 +583,7 @@ def guess_model_format(model_name: str) -> str:
         'phi15': ['moondream1', 'moondream2', 'monkey'],
         'chatml': ['34b', 'yi-6b', 'nanollava', 'internvl-chat-v1-5'],
         'fuyu': ['fuyu'],
+        'phintern': ['internvl-chat-4b'],
     }
     for format, options in model_format_match_map.items():
         if any(x in model_id for x in options):
@@ -614,7 +649,10 @@ def guess_backend(model_name: str) -> str:
     
     if 'internvl-chat-v1-5' in model_id or 'mini-internvl-chat-2b-v1-5' in model_id:
         return 'internvl-chat-v1-5'
-    
+
+    if 'internvl-chat-4b' in model_id:
+        return 'phintern'    
+
     if 'idefics2' in model_id:
         return 'idefics2'
     


### PR DESCRIPTION
Love this repo. I can finally use image captioning in silly tavern. Was using phi-vision but it's a little bit janky at OCR. This model is similar but a bit better. It gives longer descriptions. Have to fit SDXL and captioning in 22gb so it is a good fit at 8bit.

Saw it was not supported and figured I would add it after doing so for myself.

https://huggingface.co/OpenGVLab/Mini-InternVL-Chat-4B-V1-5

Only question is should the number of tiles be increased:

`def dynamic_preprocess(image, min_num=1, max_num=6, image_size=448, use_thumbnail=False):`

They claim: `Image size: dynamic resolution, max to 40 tiles of 448 x 448 (4K resolution).`

Btw: to use phi without flash attention, disable it in the model config.json